### PR TITLE
COH-29744 - Address the dependency check failure identified by GCAS

### DIFF
--- a/orders/pom.xml
+++ b/orders/pom.xml
@@ -41,6 +41,7 @@
         <version.plugin.surefire.provider.junit>1.3.2</version.plugin.surefire.provider.junit>
         <version.plugin.jib>3.4.1</version.plugin.jib>
         <version.lib.jaeger>1.8.1</version.lib.jaeger>
+        <version.lib.opentelemetry>1.34.0</version.lib.opentelemetry>
 
     </properties>
 
@@ -117,6 +118,11 @@
             <groupId>io.jaegertracing</groupId>
             <artifactId>jaeger-client</artifactId>
             <version>${version.lib.jaeger}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-sdk</artifactId>
+            <version>${version.lib.opentelemetry}</version>
         </dependency>
 
         <!-- Lombok -->


### PR DESCRIPTION
COH-29744 - Address the dependency check failure identified by GCAS with opentelemetry-sdk@1.22